### PR TITLE
C code bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ These instructions assume that you have your Xilinx Vivado licensing already set
 
 	mkdir work
 	cd work
-	curl -L https://github.com/ipbus/ipbb/archive/dev/2020g.tar.gz | tar xvz
-	source ipbb-dev-2020g/env.sh 
+	curl -L https://github.com/ipbus/ipbb/archive/dev/2021h.tar.gz | tar xvz
+	source ipbb-dev-2021h/env.sh 
 	ipbb init build
 	cd build
 

--- a/components/neo430_wrapper/software/lib/include/neo430_cmd_buffer.h
+++ b/components/neo430_wrapper/software/lib/include/neo430_cmd_buffer.h
@@ -1,0 +1,14 @@
+#ifndef CMD_BUFFER_H
+#define CMD_BUFFER_H
+
+#ifndef MAX_CMD_LENGTH
+#define MAX_CMD_LENGTH 16
+#endif
+
+#ifndef MAX_N
+#define MAX_N 16
+#endif
+
+uint8_t buffer[MAX_N];
+char command[MAX_CMD_LENGTH];
+#endif

--- a/components/neo430_wrapper/software/lib/include/neo430_i2c.h
+++ b/components/neo430_wrapper/software/lib/include/neo430_i2c.h
@@ -38,8 +38,13 @@ void print_GPO( uint16_t gpo);
 // #define DEBUG 1
 #define DELAYVAL 512
 
+#ifndef MAX_CMD_LENGTH
 #define MAX_CMD_LENGTH 16
-#define MAX_N    16
+#endif
+
+#ifndef MAX_N
+#define MAX_N 16
+#endif
 
 #define ENABLECORE 0x1 << 7
 #define STARTCMD 0x1 << 7
@@ -98,7 +103,7 @@ void print_GPO( uint16_t gpo);
 #endif
 
 
-uint8_t buffer[MAX_N];
-char command[MAX_CMD_LENGTH];
+extern uint8_t buffer[MAX_N];
+extern char command[MAX_CMD_LENGTH];
 
 #endif

--- a/components/neo430_wrapper/software/neo430_ipbus_address_terminal/main.c
+++ b/components/neo430_wrapper/software/neo430_ipbus_address_terminal/main.c
@@ -32,6 +32,7 @@
 // Libraries
 #include <stdint.h>
 #include <string.h>
+#include "neo430_cmd_buffer.h"
 #include "neo430.h"
 #include "neo430_i2c.h"
 #include "neo430_wishbone_mac_ip.h"


### PR DESCRIPTION
### Summary

Modified C code to avoid linker error regarding multiple definitions of buffer and command arrays.

Tested by building the two version of the software for neo430. Also checked the difference (git diff) between this branch and barcock/example_bug_fixes to ensure modification were same as before.  
