### PR TITLE
Dependency File Bug Fixes 

### DIFF
--- a/components/neo430_wrapper/firmware/cfg/neo430_wrapper.dep
+++ b/components/neo430_wrapper/firmware/cfg/neo430_wrapper.dep
@@ -1,28 +1,28 @@
 
 src --vhdl2008 ipbus_neo430_wrapper.vhd
 
-src -c neo430: --cd ../../../../rtl/top_templates   neo430_top_std_logic.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_top.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_twi.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_package.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_addr_gen.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_alu.vhd
-# src -c neo430: --cd ../../../../rtl/core   neo430_application_image.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_bootloader_image.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_boot_rom.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_control.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_cpu.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_dmem.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_gpio.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_imem.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_muldiv.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_reg_file.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_sysconfig.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_timer.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_uart.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_wb_interface.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_wdt.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_freq_gen.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/top_templates   neo430_top_std_logic.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_top.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_twi.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_package.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_addr_gen.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_alu.vhd
+# src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_application_image.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_bootloader_image.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_boot_rom.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_control.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_cpu.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_dmem.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_gpio.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_imem.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_muldiv.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_reg_file.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_sysconfig.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_timer.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_uart.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_wb_interface.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_wdt.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_freq_gen.vhd
 
 
 # The output of the compilation of the C running on the NEO.

--- a/components/neo430_wrapper/firmware/cfg/neo430_wrapper_24AA025E.dep
+++ b/components/neo430_wrapper/firmware/cfg/neo430_wrapper_24AA025E.dep
@@ -1,28 +1,28 @@
 
 src --vhdl2008 ipbus_neo430_wrapper.vhd
 
-src -c neo430: --cd ../../../../rtl/top_templates   neo430_top_std_logic.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_top.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_twi.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_package.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_addr_gen.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_alu.vhd
-# src -c neo430: --cd ../../../../rtl/core   neo430_application_image.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_bootloader_image.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_boot_rom.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_control.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_cpu.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_dmem.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_gpio.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_imem.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_muldiv.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_reg_file.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_sysconfig.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_timer.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_uart.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_wb_interface.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_wdt.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_freq_gen.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/top_templates   neo430_top_std_logic.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_top.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_twi.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_package.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_addr_gen.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_alu.vhd
+# src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_application_image.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_bootloader_image.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_boot_rom.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_control.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_cpu.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_dmem.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_gpio.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_imem.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_muldiv.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_reg_file.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_sysconfig.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_timer.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_uart.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_wb_interface.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_wdt.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_freq_gen.vhd
 
 
 # The output of the compilation of the C running on the NEO.

--- a/components/neo430_wrapper/firmware/cfg/neo430_wrapper_cryptoEEPROM.dep
+++ b/components/neo430_wrapper/firmware/cfg/neo430_wrapper_cryptoEEPROM.dep
@@ -1,28 +1,28 @@
 
 src --vhdl2008 ipbus_neo430_wrapper.vhd
 
-src -c neo430: --cd ../../../../rtl/top_templates   neo430_top_std_logic.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_top.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_twi.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_package.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_addr_gen.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_alu.vhd
-# src -c neo430: --cd ../../../../rtl/core   neo430_application_image.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_bootloader_image.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_boot_rom.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_control.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_cpu.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_dmem.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_gpio.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_imem.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_muldiv.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_reg_file.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_sysconfig.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_timer.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_uart.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_wb_interface.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_wdt.vhd
-src -c neo430: --cd ../../../../rtl/core   neo430_freq_gen.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/top_templates   neo430_top_std_logic.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_top.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_twi.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_package.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_addr_gen.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_alu.vhd
+# src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_application_image.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_bootloader_image.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_boot_rom.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_control.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_cpu.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_dmem.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_gpio.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_imem.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_muldiv.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_reg_file.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_sysconfig.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_timer.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_uart.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_wb_interface.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_wdt.vhd
+src -c neo430: --cd ../../../../src/neo430/rtl/core   neo430_freq_gen.vhd
 
 
 # The output of the compilation of the C running on the NEO.


### PR DESCRIPTION
### Summary

Changed path to /rtl/core directory in neo430_wrapper.dep, neo430_wrapper_24AA025E.dep and neo430_wrapper_cryptoEEPROM.dep. 
 
Checked the files on this branch are identical to counterparts on barcock/example_bug_fixes using diff command. Checked the execution of the `ipbb vivado project` command completes, and all hdl files are resolved using these new .dep files.  